### PR TITLE
Fix no-unused-vars's options

### DIFF
--- a/best-practices.js
+++ b/best-practices.js
@@ -27,6 +27,14 @@ module.exports = {
             allowSingleExtends: true,
           },
         ],
+        // temp
+        '@typescript-eslint/no-unused-vars': [
+          'warn',
+          {
+            ignoreRestSiblings: true,
+            argsIgnorePattern: '^_',
+          },
+        ],
         ...(isInstalled('react')
           ? {
               // Use type, not PropTypes.

--- a/test/typescript/functions.ts
+++ b/test/typescript/functions.ts
@@ -16,3 +16,12 @@ const squaredDifference = (values: number[]): number[] => {
 };
 
 export const variance = (values: number[]): number => sum(squaredDifference(values));
+
+export const omit = <T, K extends keyof T>(value: T, key: K): Omit<T, K> => {
+  const { [key]: removeValue, ...restValue } = value;
+  return restValue;
+};
+
+export const noop = (_value: never): void => {
+  // do nothing
+};


### PR DESCRIPTION
I often change options to pass test cases.