### PR TITLE
Fix void suppressing no floating promiss

### DIFF
--- a/best-practices.js
+++ b/best-practices.js
@@ -28,6 +28,14 @@ module.exports = {
     {
       files: ['**/*.ts', '**/*.tsx'],
       rules: {
+        // Suppress no-floating-promises
+        // https://eslint.org/docs/latest/rules/no-void
+        'no-void': [
+          'error',
+          {
+            allowAsStatement: true,
+          },
+        ],
         // Enforce using type imports.
         // https://typescript-eslint.io/rules/consistent-type-imports/
         '@typescript-eslint/consistent-type-imports': [

--- a/test/typescript/functions.ts
+++ b/test/typescript/functions.ts
@@ -52,3 +52,7 @@ export const loop = (fn: () => boolean | undefined): void => {
     if (fn() === false) break;
   }
 };
+
+export const touch = (): void => {
+  void fetch('./touch');
+};


### PR DESCRIPTION
For [no-floating-promises' ignoreVoid](https://typescript-eslint.io/rules/no-floating-promises/#ignorevoid).